### PR TITLE
Feature / Limit the number of scores in the feed

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.includes(:user).order(played_at: :desc, id: :desc).limit(25)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.includes(:user).order(played_at: :desc, id: :desc).limit(25)
+      scores = Score.order(played_at: :desc, id: :desc).limit(25)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.order(played_at: :desc, id: :desc).limit(25)
+      scores = Score.all.order(played_at: :desc, id: :desc).limit(25)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -27,7 +27,7 @@ describe Api::ScoresController, type: :request do
       expect(scores[2]['total_score']).to eq 79
     end
 
-    it 'feed should have no more than 25 entries' do
+    it 'should have no more than 25 entries' do
       30.times do
         create(:score, user: @user1, total_score: 78, played_at: '2020-05-15')
       end

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -26,6 +26,18 @@ describe Api::ScoresController, type: :request do
       expect(scores[1]['total_score']).to eq 68
       expect(scores[2]['total_score']).to eq 79
     end
+
+    it 'feed should have no more than 25 entries' do
+      30.times do
+        create(:score, user: @user1, total_score: 78, played_at: '2020-05-15')
+      end
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+      response_hash = JSON.parse(response.body)
+      scores = response_hash['scores']
+      expect(scores.count).to eq 25
+    end
   end
 
   describe 'POST create' do


### PR DESCRIPTION
Fixes: [Feed performance](https://github.com/AACraiu/golfr_backend/issues/21)


**Changes**

Add limit method to feed fetching to increase performance when feed contains many entries.

**Before**

<img width="1728" alt="Screen Shot 2022-12-08 at 15 30 58" src="https://user-images.githubusercontent.com/118171617/206459317-ed331412-3337-4124-8411-68fdd1ec3a76.png">


**After**

<img width="1728" alt="Screen Shot 2022-12-08 at 15 30 06" src="https://user-images.githubusercontent.com/118171617/206459267-366e4049-1aba-445c-8c97-7957230c1dd5.png">
sues/21)
